### PR TITLE
Added touch action to prevent double tap zoom

### DIFF
--- a/style.css
+++ b/style.css
@@ -117,6 +117,7 @@ section {
 #keyboard-container {
     width: 100%;
     text-align: center;
+    touch-action: manipulation;
 }
 
 #hack-button-container {


### PR DESCRIPTION
Without touch action, double pressing causes zoom to be enabled.